### PR TITLE
Use `ufloat` instead of `ufmt_float`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,15 @@ authors = ["Liam Gallagher <liam@liamgallagher.dev>"]
 exclude = [".github", "flake.*"]
 
 [features]
-default = ["std"]
+default = ["std", "ufmt"]
 std = []
 libm = ["dep:libm"]
-ufmt = ["dep:ufmt", "dep:ufmt_float"]
+ufmt = ["dep:ufmt", "dep:ufloat"]
 
 [dependencies]
 libm = { version = "0.2", optional = true }
 ufmt = { version = "0.2", optional = true }
-ufmt_float = { version = "0.2", optional = true }
+ufloat = { version = "0.1", optional = true }
 
 [dev-dependencies]
 approx = "0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,7 +270,7 @@ impl ufmt::uDisplay for Angle {
     where
         W: ufmt::uWrite + ?Sized,
     {
-        ufmt::uwrite!(f, "{} radians", ufmt_float::uFmt_f64::Five(self.value))
+        ufmt::uwrite!(f, "{} radians", ufloat::Uf64(self.value, 4))
     }
 }
 


### PR DESCRIPTION
`ufloat` has not been formatting negative numbers correctly so I created my own library for this.